### PR TITLE
Include check for extension-less input file

### DIFF
--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -196,10 +196,12 @@ class parse_input:
                         except:
                             self.fit[key] = val
 
-        if not os.path.splitext(self.filename)[1] == '':
+        if os.path.splitext(self.filename)[1] == 'inp':
             stem = os.path.splitext(self.filename)[0]
         else:
-            stem = os.path.splitext(self.filename)[0] + '_dir'
+            logging.error('Input file must have extension .inp')
+            raise IOError
+        
         self.fit['stem'] = stem
         self.fit['direc'] = deepcopy(stem)
         try:

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -196,11 +196,11 @@ class parse_input:
                         except:
                             self.fit[key] = val
 
-        if os.path.splitext(self.filename)[1] == '.inp':
+        if not os.path.splitext(self.filename)[1] == '':
             stem = os.path.splitext(self.filename)[0]
         else:
-            logging.error('Input file must have extension .inp')
-            raise IOError, '\nInput file must have extension .inp\n'
+            logging.error('Input file must have an extension such as .inp')
+            raise IOError, '\nInput file must have an extension such as .inp\n'
         
         self.fit['stem'] = stem
         self.fit['direc'] = deepcopy(stem)

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -234,7 +234,7 @@ class parse_input:
             try:
                 os.mkdir(self.fit['stem'])
             except OSError as e:
-                logging.error(e)
+                logging.error('Error creating directory: ' + e.strerror)
                 raise OSError(e)
                 
         sys.path.insert(0,self.fit['stem'])

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -196,7 +196,7 @@ class parse_input:
                         except:
                             self.fit[key] = val
 
-        if os.path.splitext(self.filename)[1] == 'inp':
+        if os.path.splitext(self.filename)[1] == '.inp':
             stem = os.path.splitext(self.filename)[0]
         else:
             logging.error('Input file must have extension .inp')

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -230,7 +230,7 @@ class parse_input:
             
     def initialize(self): 
         # Does output directory exist?
-        if not os.path.exists(self.fit['stem']):
+        if not os.path.isdir(self.fit['stem']):
             try:
                 os.mkdir(self.fit['stem'])
             except OSError:

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -235,7 +235,7 @@ class parse_input:
                 os.mkdir(self.fit['stem'])
             except OSError:
                 logging.error('Error creating output directory')
-                raise OSError('OS error: {0}'.format(OSError))
+                raise OSError('Error creating output directory')
                 
         sys.path.insert(0,self.fit['stem'])
         #print sys.path[0]

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -200,7 +200,7 @@ class parse_input:
             stem = os.path.splitext(self.filename)[0]
         else:
             logging.error('Input file must have extension .inp')
-            raise IOError
+            raise IOError, '\nInput file must have extension .inp\n'
         
         self.fit['stem'] = stem
         self.fit['direc'] = deepcopy(stem)

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -231,7 +231,12 @@ class parse_input:
     def initialize(self): 
         # Does output directory exist?
         if not os.path.exists(self.fit['stem']):
-            os.mkdir(self.fit['stem'])
+            try:
+                os.mkdir(self.fit['stem'])
+            except OSError:
+                logging.error('Error creating output directory')
+                raise OSError
+                
         sys.path.insert(0,self.fit['stem'])
         #print sys.path[0]
         #sys.exit()

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -235,7 +235,7 @@ class parse_input:
                 os.mkdir(self.fit['stem'])
             except OSError:
                 logging.error('Error creating output directory')
-                raise OSError
+                raise OSError('OS error: {0}'.format(OSError))
                 
         sys.path.insert(0,self.fit['stem'])
         #print sys.path[0]

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -233,9 +233,9 @@ class parse_input:
         if not os.path.isdir(self.fit['stem']):
             try:
                 os.mkdir(self.fit['stem'])
-            except OSError:
-                logging.error('Error creating output directory')
-                raise OSError('Error creating output directory')
+            except OSError as e:
+                logging.error(e)
+                raise OSError(e)
                 
         sys.path.insert(0,self.fit['stem'])
         #print sys.path[0]

--- a/FitAllB/check_input.py
+++ b/FitAllB/check_input.py
@@ -195,8 +195,11 @@ class parse_input:
                             self.fit[key] = eval(val)
                         except:
                             self.fit[key] = val
-        
-        stem = split(self.filename,'.')[0]      
+
+        if not os.path.splitext(self.filename)[1] == '':
+            stem = os.path.splitext(self.filename)[0]
+        else:
+            stem = os.path.splitext(self.filename)[0] + '_dir'
         self.fit['stem'] = stem
         self.fit['direc'] = deepcopy(stem)
         try:


### PR DESCRIPTION
check_input.py was unable to create a directory with the same name as the input filename if the filename did not have an extension. This is due to filesystem limitations on Linux.
This adds a check to the filename to see whether it has an extension.
If not, the suffix '_dir' is added to variable stem so that, later on, the directory is created as filename_dir